### PR TITLE
Update self.authenticate method in mongoid.rb.tt

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/account/mongoid.rb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/account/mongoid.rb.tt
@@ -27,7 +27,7 @@ class <%= @model_name %>
   # This method is for authentication purpose.
   #
   def self.authenticate(email, password)
-    account = where(:email => /#{Regexp.escape(email)}/i).first if email.present?
+    account = where(:email => /#{Object::Regexp.escape(email)}/i).first if email.present?
     account && account.has_password?(password) ? account : nil
   end
 


### PR DESCRIPTION
Updated self.authenticate method at line 30 to specify Object::Regexp due to a collision with Mongoid::Matchable::Regexp:Class that was producing a NoMethodError when simply calling Regexp.escape.